### PR TITLE
Arreglado problema con rutas de main css e imagenes

### DIFF
--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -9,7 +9,7 @@
 		<title>Read Only by HTML5 UP</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-		<link rel="stylesheet" href="assets/css/main.css" />
+		<link rel="stylesheet" href="/assets/css/main.css" />
 	</head>
 	<body class="is-preload">
 
@@ -25,7 +25,7 @@
 						<!-- One -->
 							<section id="one">
 								<div class="image main" data-position="center">
-									<img src="images/banner.jpg" alt="" />
+									<img src="/images/banner.jpg" alt="" />
 								</div>
 								<div class="container">
 									@yield('content')
@@ -46,13 +46,13 @@
 			</div>
 
 		<!-- Scripts -->
-			<script src="assets/js/jquery.min.js"></script>
-			<script src="assets/js/jquery.scrollex.min.js"></script>
-			<script src="assets/js/jquery.scrolly.min.js"></script>
-			<script src="assets/js/browser.min.js"></script>
-			<script src="assets/js/breakpoints.min.js"></script>
-			<script src="assets/js/util.js"></script>
-			<script src="assets/js/main.js"></script>
+			<script src="/assets/js/jquery.min.js"></script>
+			<script src="/assets/js/jquery.scrollex.min.js"></script>
+			<script src="/assets/js/jquery.scrolly.min.js"></script>
+			<script src="/assets/js/browser.min.js"></script>
+			<script src="/assets/js/breakpoints.min.js"></script>
+			<script src="/assets/js/util.js"></script>
+			<script src="/assets/js/main.js"></script>
 
 	</body>
 </html>

--- a/resources/views/partials/menu.blade.php
+++ b/resources/views/partials/menu.blade.php
@@ -1,7 +1,7 @@
 		<!-- Header -->
         <section id="header">
             <header>
-                <span class="image avatar"><img src="images/avatar.jpg" alt="" /></span>
+                <span class="image avatar"><img src="/images/avatar.jpg" alt="" /></span>
                 <h1 id="logo"><a href="#">Willis Corto</a></h1>
                 <p>I got reprogrammed by a rogue AI<br />
                 and now I'm totally cray</p>


### PR DESCRIPTION
Las rutas estaban definidas en el HTML como relativas, por lo tanto el servidor devolvía un 404 cuando quería cargar el CSS entre otros ficheros en el caso de las secciones que estaban dentro de '/productos'. Han sido cambiadas a rutas absolutas y se ha solucionado el problema.